### PR TITLE
Move image_encodings.h include location after ros.h include

### DIFF
--- a/include/MultiClassObjectDetector.h
+++ b/include/MultiClassObjectDetector.h
@@ -17,6 +17,7 @@
 #include <ros/ros.h>
 #include <ros/callback_queue.h>
 #include <sensor_msgs/Image.h>
+#include <sensor_msgs/image_encodings.h>
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 

--- a/src/MultiClassObjectDetector.cpp
+++ b/src/MultiClassObjectDetector.cpp
@@ -6,7 +6,6 @@
 //  Copyright (c) 2016 Xun Wang. All rights reserved.
 //
 
-#include <sensor_msgs/image_encodings.h>
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 


### PR DESCRIPTION
Fixes a build error, move image_encodings.h include to after the ros.h include